### PR TITLE
Update README for OpenAI >=1.0 requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # Test_codex
-This is a small demo showing how an environment can interact with the OpenAI API. Set `OPENAI_API_KEY` in your environment before running `main.py` or the web demo.
+This is a small demo showing how an environment can interact with the OpenAI API. The project expects **OpenAI Python >=1.0** and uses the new chat completion API.
+
+Set `OPENAI_API_KEY` in your environment before running `main.py` or the web demo:
+
+```bash
+export OPENAI_API_KEY=YOUR_KEY_HERE
+```
+
+If you encounter compatibility errors with the OpenAI package, try upgrading or pinning the package version as specified in `requirements.txt`:
+
+```bash
+pip install --upgrade openai  # or `pip install openai==<version>`
+```
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- document requirement of OpenAI Python >=1.0 and the use of the ChatCompletion API
- show how to set `OPENAI_API_KEY`
- note upgrading/pinning if compatibility issues occur

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684358b237fc8320b22268a6835bfa6b