### PR TITLE
Update OpenAI path in tests

### DIFF
--- a/codex_agent.py
+++ b/codex_agent.py
@@ -15,7 +15,7 @@ def codex_agent(prompt):
         openai.api_key = api_key
 
     try:
-        response = openai.ChatCompletion.create(
+        response = openai.chat.completions.create(
             model="gpt-4-turbo",
             messages=[{"role": "user", "content": prompt}],
             temperature=0.5,

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -10,7 +10,7 @@ def test_codex_agent_returns_response(monkeypatch):
     mock_choice = MagicMock()
     mock_choice.message.content = 'hello'
     mock_resp.choices = [mock_choice]
-    with patch('openai.ChatCompletion.create', return_value=mock_resp) as mock_create:
+    with patch('openai.chat.completions.create', return_value=mock_resp) as mock_create:
         result = codex_agent('hi')
         assert result == 'hello'
         mock_create.assert_called_once()


### PR DESCRIPTION
## Summary
- update agent to use new `openai.chat.completions.create`
- patch the new API path in the tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684358b020d48320ae3f0b6ef4fe4bb0