### PR TITLE
Load Flask config from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ Set `OPENAI_API_KEY` in your environment before running `main.py` or the web dem
 export OPENAI_API_KEY=YOUR_KEY_HERE
 ```
 
+### Application configuration
+
+The Flask demo reads its configuration from environment variables or an optional
+JSON file. The following variables can be set:
+
+- `FLASK_SECRET_KEY` – value for `app.secret_key` used to sign sessions.
+- `FLASK_USERS_JSON` – JSON object mapping usernames to passwords.
+- `APP_CONFIG_FILE` – path to a JSON file containing `{"secret_key": "...", "users": {...}}`.
+  Values from environment variables override the file.
+
 If you encounter compatibility errors with the OpenAI package, try upgrading or pinning the package version as specified in `requirements.txt`:
 
 ```bash

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -1,0 +1,29 @@
+import json
+import importlib
+
+import pytest
+
+
+def reload_app(monkeypatch):
+    import app
+    importlib.reload(app)
+    return app
+
+
+def test_app_loads_from_env(monkeypatch):
+    monkeypatch.setenv("FLASK_SECRET_KEY", "envsecret")
+    monkeypatch.setenv("FLASK_USERS_JSON", json.dumps({"u": "p"}))
+    app = reload_app(monkeypatch)
+    assert app.app.secret_key == "envsecret"
+    assert app.USERS == {"u": "p"}
+
+
+def test_app_loads_from_config(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"secret_key": "cfgsecret", "users": {"a": "b"}}))
+    monkeypatch.delenv("FLASK_SECRET_KEY", raising=False)
+    monkeypatch.delenv("FLASK_USERS_JSON", raising=False)
+    monkeypatch.setenv("APP_CONFIG_FILE", str(cfg))
+    app = reload_app(monkeypatch)
+    assert app.app.secret_key == "cfgsecret"
+    assert app.USERS == {"a": "b"}


### PR DESCRIPTION
## Summary
- read `FLASK_SECRET_KEY`, `FLASK_USERS_JSON` and `APP_CONFIG_FILE` in `app.py`
- document new configuration variables in README
- add tests covering configuration loading

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684361d1f4b48320963c5046064e48fc