### PR TITLE
Limit exception handling scope

### DIFF
--- a/codex_agent.py
+++ b/codex_agent.py
@@ -21,7 +21,7 @@ def codex_agent(prompt):
             temperature=0.5,
         )
         answer = response.choices[0].message.content.strip()
-    except Exception as exc:
+    except openai.OpenAIError as exc:
         print(f"OpenAI API request failed: {exc}")
         return ""
 

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1,5 +1,6 @@
 import os
 from unittest.mock import MagicMock, patch
+import openai
 
 from codex_agent import codex_agent
 
@@ -13,4 +14,12 @@ def test_codex_agent_returns_response(monkeypatch):
     with patch('openai.chat.completions.create', return_value=mock_resp) as mock_create:
         result = codex_agent('hi')
         assert result == 'hello'
+        mock_create.assert_called_once()
+
+
+def test_codex_agent_handles_openai_error(monkeypatch):
+    os.environ['OPENAI_API_KEY'] = 'test'
+    with patch('openai.chat.completions.create', side_effect=openai.OpenAIError('fail')) as mock_create:
+        result = codex_agent('hi')
+        assert result == ''
         mock_create.assert_called_once()


### PR DESCRIPTION
## Summary
- narrow broad `except Exception` in `codex_agent` to `openai.OpenAIError`
- test handling of API errors

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684361bc73f48320ad3f2f9532e86fc1