### PR TITLE
Add API key verification helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,17 @@ python app.py
 ```
 
 Then open <http://localhost:5000> in your browser.
+
+## Verifying your API key
+
+The `codex_agent` module exposes a helper function `verify_openai_key` that makes
+a tiny request to confirm your `OPENAI_API_KEY` is set correctly. Run the
+following snippet to perform the check:
+
+```python
+from codex_agent import verify_openai_key
+verify_openai_key()
+```
+
+If the API returns an authentication error, the function will print a message
+indicating that the key may be incorrect.

--- a/codex_agent.py
+++ b/codex_agent.py
@@ -28,3 +28,30 @@ def codex_agent(prompt):
 
     print(f"Codex suggests: {answer}")
     return answer
+
+
+def verify_openai_key() -> bool:
+    """Check that the configured OpenAI API key is valid by making a tiny request."""
+    if not openai.api_key:
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            print("OPENAI_API_KEY environment variable is not set")
+            return False
+        openai.api_key = api_key
+
+    try:
+        # Perform a minimal request just to verify that authentication works
+        openai.chat.completions.create(
+            model="gpt-4-turbo",
+            messages=[{"role": "user", "content": "ping"}],
+            max_tokens=1,
+        )
+    except openai.AuthenticationError as exc:
+        print(f"OpenAI API key authentication failed: {exc}")
+        return False
+    except openai.OpenAIError as exc:
+        print(f"OpenAI API request failed: {exc}")
+        return False
+
+    print("OpenAI API key appears to be valid!")
+    return True

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -2,7 +2,7 @@ import os
 from unittest.mock import MagicMock, patch
 import openai
 
-from codex_agent import codex_agent
+from codex_agent import codex_agent, verify_openai_key
 
 
 def test_codex_agent_returns_response(monkeypatch):
@@ -22,4 +22,18 @@ def test_codex_agent_handles_openai_error(monkeypatch):
     with patch('openai.chat.completions.create', side_effect=openai.OpenAIError('fail')) as mock_create:
         result = codex_agent('hi')
         assert result == ''
+        mock_create.assert_called_once()
+
+
+def test_verify_openai_key_success(monkeypatch):
+    os.environ['OPENAI_API_KEY'] = 'test'
+    with patch('openai.chat.completions.create', return_value=MagicMock()) as mock_create:
+        assert verify_openai_key()
+        mock_create.assert_called_once()
+
+
+def test_verify_openai_key_failure(monkeypatch):
+    os.environ['OPENAI_API_KEY'] = 'test'
+    with patch('openai.chat.completions.create', side_effect=openai.OpenAIError('fail')) as mock_create:
+        assert not verify_openai_key()
         mock_create.assert_called_once()


### PR DESCRIPTION
## Summary
- implement `verify_openai_key` to validate the configured OpenAI key
- test the helper in `tests/test_codex_agent.py`
- document key verification in `README.md`

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436e1fa1a8832084322eff2f8b2f8c