### PR TITLE
Fix OpenAI client usage

### DIFF
--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -2,38 +2,51 @@ import os
 from unittest.mock import MagicMock, patch
 import openai
 
+import codex_agent
 from codex_agent import codex_agent, verify_openai_key
 
 
 def test_codex_agent_returns_response(monkeypatch):
     os.environ['OPENAI_API_KEY'] = 'test'
+    codex_agent._client = None
     mock_resp = MagicMock()
     mock_choice = MagicMock()
     mock_choice.message.content = 'hello'
     mock_resp.choices = [mock_choice]
-    with patch('openai.chat.completions.create', return_value=mock_resp) as mock_create:
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = mock_resp
+    with patch('codex_agent._get_client', return_value=mock_client):
         result = codex_agent('hi')
         assert result == 'hello'
-        mock_create.assert_called_once()
+        mock_client.chat.completions.create.assert_called_once()
 
 
 def test_codex_agent_handles_openai_error(monkeypatch):
     os.environ['OPENAI_API_KEY'] = 'test'
-    with patch('openai.chat.completions.create', side_effect=openai.OpenAIError('fail')) as mock_create:
+    codex_agent._client = None
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = openai.OpenAIError('fail')
+    with patch('codex_agent._get_client', return_value=mock_client):
         result = codex_agent('hi')
         assert result == ''
-        mock_create.assert_called_once()
+        mock_client.chat.completions.create.assert_called_once()
 
 
 def test_verify_openai_key_success(monkeypatch):
     os.environ['OPENAI_API_KEY'] = 'test'
-    with patch('openai.chat.completions.create', return_value=MagicMock()) as mock_create:
+    codex_agent._client = None
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = MagicMock()
+    with patch('codex_agent._get_client', return_value=mock_client):
         assert verify_openai_key()
-        mock_create.assert_called_once()
+        mock_client.chat.completions.create.assert_called_once()
 
 
 def test_verify_openai_key_failure(monkeypatch):
     os.environ['OPENAI_API_KEY'] = 'test'
-    with patch('openai.chat.completions.create', side_effect=openai.OpenAIError('fail')) as mock_create:
+    codex_agent._client = None
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = openai.OpenAIError('fail')
+    with patch('codex_agent._get_client', return_value=mock_client):
         assert not verify_openai_key()
-        mock_create.assert_called_once()
+        mock_client.chat.completions.create.assert_called_once()


### PR DESCRIPTION
## Summary
- switch to using a lazily created `openai.OpenAI` client
- update helper tests to patch `_get_client` rather than the OpenAI class

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844852e2a708320b5ad1725cc77838b