### PR TITLE
Redesign chat UI

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -2,54 +2,90 @@ body {
     font-family: Arial, sans-serif;
     margin: 0;
     padding: 0;
-    display: flex;
     height: 100vh;
+    display: flex;
+    color: #333;
 }
+
 .container {
     flex: 1;
     display: flex;
 }
+
 .sidebar {
-    width: 250px;
-    background: #f0f0f0;
+    width: 260px;
+    background: #202123;
+    color: #fff;
+    display: flex;
+    flex-direction: column;
+}
+.sidebar .logo {
     padding: 20px;
+    text-align: center;
+    font-weight: bold;
+    border-bottom: 1px solid #333;
+}
+.chats {
+    list-style: none;
+    padding: 10px;
+    margin: 0;
+    flex: 1;
     overflow-y: auto;
-    border-right: 1px solid #ccc;
 }
-.sidebar h3 {
-    margin-top: 0;
+.chats li {
+    padding: 8px;
+    margin-bottom: 6px;
+    background: #2d2e30;
+    border-radius: 4px;
+    cursor: pointer;
 }
-.chat {
+
+.main {
     flex: 1;
     display: flex;
     flex-direction: column;
-    padding: 20px;
+    background: #fff;
 }
-#chat {
-    flex: 1;
-    border: 1px solid #ccc;
-    padding: 10px;
-    overflow-y: auto;
-    margin-bottom: 10px;
-}
-#question {
-    width: 100%;
-    min-height: 50px;
-    resize: none;
-    padding: 10px;
-}
-.buttons {
-    margin-top: 5px;
-}
-button {
-    padding: 8px 16px;
-    margin-right: 5px;
-}
-.logo {
-    display: inline-block;
-    width: 32px;
+.welcome {
     text-align: center;
-    vertical-align: middle;
+    margin-top: 40px;
+    font-size: 24px;
+    color: #888;
+}
+.chat {
+    flex: 1;
+    padding: 20px;
+    overflow-y: auto;
+}
+.input-area {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    border-top: 1px solid #eee;
+}
+.input-wrapper {
+    position: relative;
+    flex: 1;
+    max-width: 600px;
+}
+.input-wrapper input {
+    width: 100%;
+    padding: 12px 40px 12px 12px;
+    border-radius: 20px;
+    border: 1px solid #ccc;
+    font-size: 16px;
+}
+.input-wrapper .icon {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    cursor: pointer;
+}
+.input-area button {
+    margin-left: 10px;
+    padding: 8px 16px;
 }
 .message.user {
     font-weight: bold;

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,37 +7,42 @@
 </head>
 <body>
 <div class="container">
-    <div class="sidebar">
-        <h3>History</h3>
-        <ul id="history"></ul>
-    </div>
-    <div class="chat">
-        <h1><span class="logo">🤖</span> Chat Demo</h1>
-        <div id="chat"></div>
-        <textarea id="question" placeholder="Type your question"></textarea>
-        <div class="buttons">
+    <aside class="sidebar">
+        <div class="logo">🤖 ChatDemo</div>
+        <ul id="history" class="chats"></ul>
+    </aside>
+    <main class="main">
+        <div id="welcome" class="welcome">Type and Ask anything</div>
+        <div id="chat" class="chat"></div>
+        <div class="input-area">
+            <div class="input-wrapper">
+                <input id="question" type="text" placeholder="Type here" />
+                <span class="icon" title="Insert image/video">📎</span>
+            </div>
             <button id="askBtn">Ask</button>
             <button id="clearBtn">Clear</button>
         </div>
-    </div>
+    </main>
 </div>
 <script>
 const historyList = document.getElementById('history');
 const chatDiv = document.getElementById('chat');
-const textarea = document.getElementById('question');
+const input = document.getElementById('question');
+const welcome = document.getElementById('welcome');
 
-function autoResize() {
-    textarea.style.height = 'auto';
-    textarea.style.height = textarea.scrollHeight + 'px';
-}
-textarea.addEventListener('input', autoResize);
+input.addEventListener('keypress', (e) => {
+    if (e.key === 'Enter') {
+        e.preventDefault();
+        sendQuestion();
+    }
+});
 
 async function sendQuestion() {
-    const question = textarea.value.trim();
+    const question = input.value.trim();
     if (!question) return;
     appendMessage('user', question);
-    textarea.value = '';
-    autoResize();
+    input.value = '';
+    welcome.style.display = 'none';
     const response = await fetch('/ask', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -59,6 +64,7 @@ function appendMessage(role, text) {
 function addToHistory(q, a) {
     const li = document.createElement('li');
     li.textContent = q;
+    li.setAttribute('contenteditable', 'true');
     li.onclick = () => alert(a);
     historyList.appendChild(li);
 }
@@ -66,6 +72,7 @@ function addToHistory(q, a) {
 function clearChat() {
     chatDiv.innerHTML = '';
     historyList.innerHTML = '';
+    welcome.style.display = 'block';
 }
 
 document.getElementById('askBtn').addEventListener('click', sendQuestion);


### PR DESCRIPTION
## Summary
- overhaul the chat page layout to mimic ChatGPT
- implement editable chat list and new input style
- modernize the CSS with flexbox

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68449eff563c83209702f761976e9739