### PR TITLE
Fix main script entrypoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,18 +4,27 @@
 from environment import Environment
 from codex_agent import codex_agent
 
-env = Environment()
-state = env.reset()
-done = False
 
-while not done:
-    user_text = input("Enter additional instructions (or press Enter for none): ")
-    prompt = f"The current state is {state}. {user_text} Suggest a helpful next action."
-    action_str = codex_agent(prompt)
-    action = {"suggested_action": action_str}
+def main() -> None:
+    """Run an interactive loop with the :class:`Environment`."""
+    env = Environment()
+    state = env.reset()
+    done = False
 
-    state, reward, done = env.step(action)
-    print(f"State after action: {state}, Reward: {reward}, Done: {done}\n")
+    while not done:
+        user_text = input(
+            "Enter additional instructions (or press Enter for none): "
+        )
+        prompt = f"The current state is {state}. {user_text} Suggest a helpful next action."
+        action_str = codex_agent(prompt)
+        action = {"suggested_action": action_str}
 
-    if done:
-        print("Task completed!")
+        state, reward, done = env.step(action)
+        print(f"State after action: {state}, Reward: {reward}, Done: {done}\n")
+
+        if done:
+            print("Task completed!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- wrap interactive CLI in a `main()` function
- call `main()` behind `if __name__ == "__main__"` guard

## Testing
- `pip install -q black`
- `black main.py --line-length 79`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ee9944588320acea74d70e16ac71