### PR TITLE
Fix chat display issues

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,18 +4,27 @@
 from environment import Environment
 from codex_agent import codex_agent
 
-env = Environment()
-state = env.reset()
-done = False
 
-while not done:
-    user_text = input("Enter additional instructions (or press Enter for none): ")
-    prompt = f"The current state is {state}. {user_text} Suggest a helpful next action."
-    action_str = codex_agent(prompt)
-    action = {"suggested_action": action_str}
+def main() -> None:
+    """Run an interactive loop with the :class:`Environment`."""
+    env = Environment()
+    state = env.reset()
+    done = False
 
-    state, reward, done = env.step(action)
-    print(f"State after action: {state}, Reward: {reward}, Done: {done}\n")
+    while not done:
+        user_text = input(
+            "Enter additional instructions (or press Enter for none): "
+        )
+        prompt = f"The current state is {state}. {user_text} Suggest a helpful next action."
+        action_str = codex_agent(prompt)
+        action = {"suggested_action": action_str}
 
-    if done:
-        print("Task completed!")
+        state, reward, done = env.step(action)
+        print(f"State after action: {state}, Reward: {reward}, Done: {done}\n")
+
+        if done:
+            print("Task completed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/static/styles.css
+++ b/static/styles.css
@@ -7,6 +7,13 @@ body {
     color: #333;
 }
 
+.login-page {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: #f5f5f5;
+}
+
 .container {
     flex: 1;
     display: flex;
@@ -56,6 +63,9 @@ body {
     flex: 1;
     padding: 20px;
     overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
 }
 .input-area {
     display: flex;
@@ -87,9 +97,20 @@ body {
     margin-left: 10px;
     padding: 8px 16px;
 }
+.message {
+    max-width: 80%;
+    padding: 8px 12px;
+    border-radius: 6px;
+    line-height: 1.4;
+    word-wrap: break-word;
+}
 .message.user {
+    align-self: flex-end;
+    background: #e0e0e0;
     font-weight: bold;
 }
 .message.assistant {
-    color: green;
+    align-self: flex-start;
+    background: #dcffe4;
+    color: #333;
 }

--- a/templates/login.html
+++ b/templates/login.html
@@ -10,7 +10,7 @@
         input { margin-bottom: 10px; padding: 8px; }
     </style>
 </head>
-<body>
+<body class="login-page">
 <div class="login-container">
     <h2>Sign In</h2>
     <form method="post">


### PR DESCRIPTION
## Summary
- improve chat message styling so assistant replies are visible
- center login page with new `login-page` style

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845ee9944588320acea74d70e16ac71