### PR TITLE
Update login and chat UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,7 +57,8 @@ def login_required(func):
 @app.route('/')
 @login_required
 def index():
-    return render_template('index.html')
+    username = session.get('username')
+    return render_template('index.html', username=username)
 
 @app.route('/ask', methods=['POST'])
 def ask():

--- a/static/styles.css
+++ b/static/styles.css
@@ -4,7 +4,25 @@ body {
     padding: 0;
     height: 100vh;
     display: flex;
+    flex-direction: column;
     color: #333;
+}
+
+.topbar {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 20px;
+    background: #202123;
+    color: #fff;
+}
+.topbar .logout {
+    color: #fff;
+    text-decoration: none;
+}
+.topbar .logout:hover {
+    text-decoration: underline;
 }
 
 .login-page {
@@ -12,6 +30,11 @@ body {
     justify-content: center;
     align-items: center;
     background: #f5f5f5;
+}
+.login-page .error {
+    color: red;
+    margin-bottom: 10px;
+    text-align: center;
 }
 
 .container {

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,10 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
 <body>
+<header class="topbar">
+    <div class="welcome-user">Logged in as {{ username }}</div>
+    <a href="{{ url_for('logout') }}" class="logout">Logout</a>
+</header>
 <div class="container">
     <aside class="sidebar">
         <div class="logo">🤖 ChatDemo</div>

--- a/templates/login.html
+++ b/templates/login.html
@@ -13,6 +13,9 @@
 <body class="login-page">
 <div class="login-container">
     <h2>Sign In</h2>
+    {% if error %}
+    <div class="error">{{ error }}</div>
+    {% endif %}
     <form method="post">
         <input type="text" name="username" placeholder="Username" required>
         <input type="password" name="password" placeholder="Password" required>


### PR DESCRIPTION
## Summary
- show logged in user and a logout link in the chat page
- display login errors and tweak login page styling
- add a top bar style and error styles to `styles.css`
- pass username when rendering `index.html`

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685425edef1c8320bfb6344ae2bb4f9d