### PR TITLE
Improve Flask security

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ export GEMINI_API_KEY=YOUR_KEY_HERE
 The Flask demo reads its configuration from environment variables or an optional
 JSON file. The following variables can be set:
 
-- `FLASK_SECRET_KEY` – value for `app.secret_key` used to sign sessions.
-- `FLASK_USERS_JSON` – JSON object mapping usernames to passwords.
+- `FLASK_SECRET_KEY` – value for `app.secret_key` used to sign sessions. If not set, a random key is generated at startup.
+- `FLASK_USERS_JSON` – JSON object mapping usernames to passwords. Passwords are hashed on load using Werkzeug.
 - `APP_CONFIG_FILE` – path to a JSON file containing `{"secret_key": "...", "users": {...}}`.
   Values from environment variables override the file.
 

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -1,5 +1,6 @@
 import json
 import importlib
+from werkzeug.security import check_password_hash
 
 import pytest
 
@@ -15,7 +16,8 @@ def test_app_loads_from_env(monkeypatch):
     monkeypatch.setenv("FLASK_USERS_JSON", json.dumps({"u": "p"}))
     app = reload_app(monkeypatch)
     assert app.app.secret_key == "envsecret"
-    assert app.USERS == {"u": "p"}
+    assert "u" in app.USERS
+    assert check_password_hash(app.USERS["u"], "p")
 
 
 def test_app_loads_from_config(tmp_path, monkeypatch):
@@ -26,4 +28,5 @@ def test_app_loads_from_config(tmp_path, monkeypatch):
     monkeypatch.setenv("APP_CONFIG_FILE", str(cfg))
     app = reload_app(monkeypatch)
     assert app.app.secret_key == "cfgsecret"
-    assert app.USERS == {"a": "b"}
+    assert "a" in app.USERS
+    assert check_password_hash(app.USERS["a"], "b")


### PR DESCRIPTION
## Summary
- hash user passwords at startup and generate a random secret key
- validate hashed credentials on login
- show user-friendly error message when API call fails
- document changes in README
- update unit tests

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686050fffc588320be2c82ce7f87488f